### PR TITLE
Adjust hero buttons for responsive layout

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -29,6 +29,7 @@ const Footer = () => {
             title="Let's get in touch"
             icon={<FaLocationArrow />}
             position="right"
+            containerClassName="mt-6 md:mt-10 md:w-60"
           />
         </a>
       </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -61,13 +61,24 @@ const Hero = () => {
             Businesses Grow.
           </p>
 
-          <a href="#about">
-            <MagicButton
-              title="Show our work"
-              icon={<FaLocationArrow />}
-              position="right"
-            />
-          </a>
+          <div className="mt-6 md:mt-10 flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center sm:gap-4">
+            <a href="#about" className="w-full sm:w-auto">
+              <MagicButton
+                title="Show our work"
+                icon={<FaLocationArrow />}
+                position="right"
+                containerClassName="sm:w-auto md:w-60"
+              />
+            </a>
+            <a href="#contact" className="w-full sm:w-auto">
+              <MagicButton
+                title="Get a free quote"
+                icon={<FaLocationArrow />}
+                position="right"
+                containerClassName="sm:w-auto md:w-60"
+              />
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/components/MagicButton.tsx
+++ b/components/MagicButton.tsx
@@ -5,8 +5,8 @@ import React from "react";
  *  Link: https://ui.aceternity.com/components/tailwindcss-buttons
  *
  *  change border radius to rounded-lg
- *  add margin of md:mt-10
  *  remove focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50
+ *  allow custom spacing via containerClassName
  */
 const MagicButton = ({
   title,
@@ -14,16 +14,20 @@ const MagicButton = ({
   position,
   handleClick,
   otherClasses,
+  containerClassName,
 }: {
   title: string;
   icon: React.ReactNode;
   position: string;
   handleClick?: () => void;
   otherClasses?: string;
+  containerClassName?: string;
 }) => {
   return (
     <button
-      className="relative inline-flex h-12 w-full md:w-60 md:mt-10 overflow-hidden rounded-lg p-[1px] focus:outline-none"
+      className={`relative inline-flex h-12 w-full overflow-hidden rounded-lg p-[1px] focus:outline-none ${
+        containerClassName ?? ""
+      }`}
       onClick={handleClick}
     >
       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />


### PR DESCRIPTION
## Summary
- add responsive layout for the hero call-to-action buttons and introduce a footer quote link
- expose a containerClassName prop on MagicButton for layout-specific sizing and spacing
- update the footer CTA to use the new spacing hook for consistent alignment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db7266e4e48325820b99cfc0253a7d